### PR TITLE
[WIP] Expose blurhash string

### DIFF
--- a/src/__tests__/__snapshots__/generate-blurhash.js.snap
+++ b/src/__tests__/__snapshots__/generate-blurhash.js.snap
@@ -3,11 +3,13 @@
 exports[`gatsby-transformer-blurhash generateBlurhash cached 1`] = `
 Object {
   "base64Image": "cached base64 image string",
+  "hash": "mocked blurhashed encoded string",
 }
 `;
 
 exports[`gatsby-transformer-blurhash generateBlurhash not cached 1`] = `
 Object {
   "base64Image": "canvas data url",
+  "hash": "mocked blurhashed encoded string",
 }
 `;

--- a/src/__tests__/generate-blurhash.js
+++ b/src/__tests__/generate-blurhash.js
@@ -32,7 +32,10 @@ jest.mock("canvas", () => ({
 
 jest.mock("fs-extra", () => ({
 	exists: jest.fn(() => false),
-	readFileSync: jest.fn(() => "cached base64 image string"),
+	readFileSync: jest.fn(() => (JSON.stringify({
+		"base64Image": "cached base64 image string",
+		"hash": "mocked blurhashed encoded string"
+	}))),
 	writeFile: jest.fn(),
 }));
 

--- a/src/__tests__/generate-blurhash.js
+++ b/src/__tests__/generate-blurhash.js
@@ -1,6 +1,6 @@
 const { resolve } = require("path");
 
-const { exists, readFile, writeFile } = require("fs-extra");
+const { exists, readFileSync, writeFile } = require("fs-extra");
 const blurhash = require("blurhash");
 const { createCanvas, loadImage } = require("canvas");
 
@@ -32,7 +32,7 @@ jest.mock("canvas", () => ({
 
 jest.mock("fs-extra", () => ({
 	exists: jest.fn(() => false),
-	readFile: jest.fn(() => "cached base64 image string"),
+	readFileSync: jest.fn(() => "cached base64 image string"),
 	writeFile: jest.fn(),
 }));
 
@@ -44,7 +44,7 @@ afterEach(() => {
 	loadImage.mockClear();
 
 	exists.mockClear();
-	readFile.mockClear();
+	readFileSync.mockClear();
 	writeFile.mockClear();
 });
 
@@ -79,7 +79,7 @@ describe("gatsby-transformer-blurhash", () => {
 			});
 			expect(result).toMatchSnapshot();
 
-			const readFileArgs = readFile.mock.calls[0];
+			const readFileArgs = readFileSync.mock.calls[0];
 			expect(readFileArgs[0]).toBe(absolutePath);
 
 			expect(blurhash.encode).toHaveBeenCalledTimes(1);
@@ -91,7 +91,7 @@ describe("gatsby-transformer-blurhash", () => {
 
 			expect(exists).toHaveBeenCalledTimes(1);
 			expect(writeFile).toHaveBeenCalledTimes(1);
-			expect(readFile).toHaveBeenCalledTimes(1);
+			expect(readFileSync).toHaveBeenCalledTimes(1);
 		});
 
 		it("cached", async () => {
@@ -122,7 +122,7 @@ describe("gatsby-transformer-blurhash", () => {
 
 			expect(exists).toHaveBeenCalledTimes(1);
 			expect(writeFile).toHaveBeenCalledTimes(0);
-			expect(readFile).toHaveBeenCalledTimes(1);
+			expect(readFileSync).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/src/extend-node-type.js
+++ b/src/extend-node-type.js
@@ -47,6 +47,7 @@ async function blurhashSharp({ cache, getNodeAndSavePathDependency, store }) {
 				name: "BlurhashSharp",
 				fields: {
 					base64Image: { type: GraphQLString },
+					hash: { type: GraphQLString }
 				},
 			}),
 			args: {


### PR DESCRIPTION
Hi!

This PR adds a new property to the object returned by blurhash resolver, called `hash` that exposes ”blurhash” encoded preview image.

I had changed the file-system caching file extension to `.json`, to accommodate the change to having two fields. 

Also, does it make sense to actually cache also in a file? Is Gatsby’s caching not enough? Just curious to understand why you have this double-gated system there. 

After code is reviewed I will update README to add `hash` option and remove [WIP] tag.

In README, I’d also suggest using much smaller size for the example query (say `width: 32`) as recommended by blurhash docs – this will decrease the size of currently generated base64 string *and* make decoding very fast on the client.

I will also add a reference to https://github.com/woltapp/react-blurhash

Fixes #2 